### PR TITLE
Add /userinfo endpoint

### DIFF
--- a/packages/openauth/src/issuer.ts
+++ b/packages/openauth/src/issuer.ts
@@ -130,6 +130,7 @@ import { Hono } from "hono/tiny"
 import { handle as awsHandle } from "hono/aws-lambda"
 import { Context } from "hono"
 import { deleteCookie, getCookie, setCookie } from "hono/cookie"
+import type { v1 } from "@standard-schema/spec"
 
 /**
  * Sets the subject payload in the JWT token and returns the response.
@@ -190,7 +191,7 @@ import {
   UnauthorizedClientError,
   UnknownStateError,
 } from "./error.js"
-import { compactDecrypt, CompactEncrypt, SignJWT } from "jose"
+import { compactDecrypt, CompactEncrypt, jwtVerify, SignJWT } from "jose"
 import { Storage, StorageAdapter } from "./storage/storage.js"
 import { encryptionKeys, legacySigningKeys, signingKeys } from "./keys.js"
 import { validatePKCE } from "./pkce.js"
@@ -1069,6 +1070,63 @@ export function issuer<
         c.req.raw,
       ),
     )
+  })
+
+  app.get("/userinfo", async (c) => {
+    const header = c.req.header("Authorization")
+
+    if (!header) {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description: "Missing Authorization header",
+        },
+        400,
+      )
+    }
+
+    const [type, token] = header.split(" ")
+
+    if (type !== "Bearer") {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description: "Missing or invalid Authorization header",
+        },
+        400,
+      )
+    }
+
+    if (!token) {
+      return c.json(
+        {
+          error: "invalid_request",
+          error_description: "Missing token",
+        },
+        400,
+      )
+    }
+
+    const result = await jwtVerify<{
+      mode: "access"
+      type: keyof SubjectSchema
+      properties: v1.InferInput<SubjectSchema[keyof SubjectSchema]>
+    }>(token, () => signingKey.then((item) => item.public), {
+      issuer: issuer(c),
+    })
+
+    const validated = await input.subjects[result.payload.type][
+      "~standard"
+    ].validate(result.payload.properties)
+
+    if (!validated.issues && result.payload.mode === "access") {
+      return c.json(validated.value as SubjectSchema)
+    }
+
+    return c.json({
+      error: "invalid_token",
+      error_description: "Invalid token",
+    })
   })
 
   app.onError(async (err, c) => {

--- a/packages/openauth/test/issuer.test.ts
+++ b/packages/openauth/test/issuer.test.ts
@@ -337,3 +337,54 @@ describe("refresh token", () => {
     expect(reused.error).toBe("invalid_request")
   })
 })
+
+describe("user info", () => {
+  let tokens: { access: string; refresh: string }
+  let client: ReturnType<typeof createClient>
+
+  const generateTokens = async (issuer: typeof auth) => {
+    const { challenge, url } = await client.authorize(
+      "https://client.example.com/callback",
+      "code",
+      { pkce: true },
+    )
+    let response = await issuer.request(url)
+    response = await issuer.request(response.headers.get("location")!, {
+      headers: {
+        cookie: response.headers.get("set-cookie")!,
+      },
+    })
+    const location = new URL(response.headers.get("location")!)
+    const code = location.searchParams.get("code")
+    const exchanged = await client.exchange(
+      code!,
+      "https://client.example.com/callback",
+      challenge.verifier,
+    )
+    if (exchanged.err) throw exchanged.err
+    return exchanged.tokens
+  }
+
+  const createClientAndTokens = async (issuer: typeof auth) => {
+    client = createClient({
+      issuer: "https://auth.example.com",
+      clientID: "123",
+      fetch: (a, b) => Promise.resolve(issuer.request(a, b)),
+    })
+    tokens = await generateTokens(issuer)
+  }
+
+  beforeEach(async () => {
+    await createClientAndTokens(auth)
+  })
+
+  test("success", async () => {
+    const response = await auth.request("https://auth.example.com/userinfo", {
+      headers: { Authorization: `Bearer ${tokens.access}` },
+    })
+
+    const userinfo = await response.json()
+
+    expect(userinfo).toStrictEqual({ userID: "123" })
+  })
+})


### PR DESCRIPTION
Closes #159

I added a /userinfo endpoint similar to the one provided by other IdP like Auth0 and Okta.

This endpoint allows you send a request with an access token and retrieve the subject properties (the user data) of the token.

This endpoint is part of OIDC spec, although since OpenAuth doesn't have support for scopes yet this just return the subject data, if in the future scopes support is added this should only work if the access token requested the `openid`, `profile` and `email` scopes. 