### PR TITLE
Fix #204 - cloudflare KV put sometimes fails due to TTL <60

### DIFF
--- a/packages/openauth/src/storage/cloudflare.ts
+++ b/packages/openauth/src/storage/cloudflare.ts
@@ -44,7 +44,7 @@ export function CloudflareStorage(
     async set(key: string[], value: any, expiry?: Date) {
       await options.namespace.put(joinKey(key), JSON.stringify(value), {
         expirationTtl: expiry
-          ? Math.floor((expiry.getTime() - Date.now()) / 1000)
+          ? Math.max(Math.floor((expiry.getTime() - Date.now()) / 1000), 60)
           : undefined,
       })
     },


### PR DESCRIPTION
https://github.com/toolbeam/openauth/issues/204

Adds `Math.max(..., 60)` to the CF KV PUT TTL so its never be below 60 