### PR TITLE
make provider button copy configurable

### DIFF
--- a/packages/openauth/src/ui/select.tsx
+++ b/packages/openauth/src/ui/select.tsx
@@ -26,6 +26,15 @@
 
 import { Layout } from "./base.js"
 
+const DEFAULT_COPY = {
+  /**
+   * Copy for the provider button.
+   */
+  button_provider: "Continue with",
+}
+
+export type SelectCopy = typeof DEFAULT_COPY
+
 export interface SelectProps {
   /**
    * An object with all the providers and their config; where the key is the provider name.
@@ -56,6 +65,10 @@ export interface SelectProps {
       display?: string
     }
   >
+  /**
+   * Custom copy for the UI.
+   */
+  copy?: Partial<SelectCopy>
 }
 
 export function Select(props?: SelectProps) {
@@ -63,6 +76,11 @@ export function Select(props?: SelectProps) {
     providers: Record<string, string>,
     _req: Request,
   ): Promise<Response> => {
+    const copy = {
+      ...DEFAULT_COPY,
+      ...props?.copy,
+    }
+
     const jsx = (
       <Layout>
         <div data-component="form">
@@ -77,7 +95,7 @@ export function Select(props?: SelectProps) {
                 data-color="ghost"
               >
                 {icon && <i data-slot="icon">{icon}</i>}
-                Continue with {match?.display || DISPLAY[type] || type}
+                {copy.button_provider} {match?.display || DISPLAY[type] || type}
               </a>
             )
           })}


### PR DESCRIPTION
A configuration option like this would be helpful, allowing me to remove the custom select I created to change the button language.