### PR TITLE
allow oauth style autodetection

### DIFF
--- a/.changeset/stupid-boats-play.md
+++ b/.changeset/stupid-boats-play.md
@@ -1,0 +1,5 @@
+---
+"@openauthjs/openauth": patch
+---
+
+allow auth style autodetection

--- a/packages/openauth/src/issuer.ts
+++ b/packages/openauth/src/issuer.ts
@@ -830,7 +830,6 @@ export function issuer<
             400,
           )
         }
-        await Storage.remove(storage, key)
         if (payload.redirectURI !== form.get("redirect_uri")) {
           return c.json(
             {
@@ -879,6 +878,7 @@ export function issuer<
           }
         }
         const tokens = await generateTokens(c, payload)
+        await Storage.remove(storage, key)
         return c.json({
           access_token: tokens.access,
           expires_in: tokens.expiresIn,


### PR DESCRIPTION
fixes #231

Allows golang/oauth2 to autodetect the auth style used by openauth (`client_id` passed in params).