### PR TITLE
feat(provider): add POST callback and id_token handling for OAuth2

### DIFF
--- a/packages/openauth/src/provider/google.ts
+++ b/packages/openauth/src/provider/google.ts
@@ -58,6 +58,7 @@ export function GoogleProvider(config: GoogleConfig) {
     endpoint: {
       authorization: "https://accounts.google.com/o/oauth2/v2/auth",
       token: "https://oauth2.googleapis.com/token",
+      jwks: "https://www.googleapis.com/oauth2/v3/certs",
     },
   })
 }

--- a/packages/openauth/src/provider/oauth2.ts
+++ b/packages/openauth/src/provider/oauth2.ts
@@ -192,7 +192,6 @@ export function Oauth2Provider(
       idTokenPayload = payload;
     }
     
-    // Create tokenset with decoded ID token claims if available
     return ctx.success(c, {
       clientID: config.clientID,
       tokenset: {


### PR DESCRIPTION
resolves #82 

- Add form_post response_mode support for Apple Sign In
- Implement POST callback route in OAuth2 provider
- Add ID token verification using JWKS endpoint
- Refactor callback logic to reduce duplication
- Extract and expose decoded ID token claims

This change enables Apple Sign In with name and email scopes which requires form_post response mode and proper handling of the ID token.